### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/src/lib/api/films.ts
+++ b/src/lib/api/films.ts
@@ -70,8 +70,13 @@ export async function getFilms(page: number): Promise<MovieListResponse> {
  * ```
  */
 export async function getFilmBySlug(slug: string | string[]): Promise<MovieResponse> {
+  // SSRF mitigation: Only allow slugs that are alphanumeric, hyphens, or underscores
+  const slugStr = Array.isArray(slug) ? slug.join('-') : slug;
+  if (!/^[a-zA-Z0-9-_]+$/.test(slugStr)) {
+    throw new Error('Invalid slug format');
+  }
   return fetchWithErrorHandling<MovieResponse>(
-    `${API_CONFIG.BASE_URL}${API_CONFIG.FILM_PATH}/${slug}`,
+    `${API_CONFIG.BASE_URL}${API_CONFIG.FILM_PATH}/${slugStr}`,
   )
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dt418/nghien-phim/security/code-scanning/2](https://github.com/dt418/nghien-phim/security/code-scanning/2)

To fix the SSRF vulnerability, we need to ensure that the `slug` parameter in `getFilmBySlug` cannot be used to manipulate the URL in a dangerous way. The best approach is to strictly validate or sanitize the `slug` value before using it in the URL. Since slugs are typically URL-safe strings (e.g., alphanumeric, hyphens), we can enforce a regular expression that only allows such characters. If the input does not match the expected pattern, we should throw an error. This change should be made in `src/lib/api/films.ts` within the `getFilmBySlug` function, before constructing the URL.

No changes are needed in `src/lib/api/fetch.ts`, as the vulnerability is in how the URL is constructed, not in the fetch wrapper itself.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
